### PR TITLE
Improved instructions about Debian/Ubuntu systems

### DIFF
--- a/Building-on-Linux.md
+++ b/Building-on-Linux.md
@@ -36,11 +36,11 @@ cd ./install/bin
 ./opentrack
 ```
 
-**Note:** The resulting build output will be placed in the `install/` directory. It will not 'install' itself anywhere outside of the current directory. 
+**Note:** The resulting build output will be placed in the `install/` directory. It will not 'install' itself anywhere outside of the current directory.
 
 ## Building on Manjaro
 
-### Installing Dependencies
+### Dependencies
 * `cmake`
 * `git`
 * `qt5-tools`

--- a/Building-on-Linux.md
+++ b/Building-on-Linux.md
@@ -4,7 +4,8 @@ Opentrack does not provide binaries for Linux users. The following is a brief, m
 
 The following dependencies are for **Debian-based** systems, however it should give users of other distros a rough idea of what they will need to hunt for in their own package manager. Users of other distributions are encouraged to expand upon this guide.
 
-### Dependencies
+### Installing Dependencies
+The folowing dependencies are required in order to correctly build OpenTrack on Debian/Ubuntu systems:
 * `build-essentials`
 * `cmake`
 * `git`
@@ -13,11 +14,17 @@ The following dependencies are for **Debian-based** systems, however it should g
 * `libproc2-dev`
 * `libopencv-dev`
 
+On most Debian/Ubuntu systems the required dependencies can be installed as follows:
+```sh
+sudo apt update
+sudo apt install build-essential cmake git qttools5-dev qtbase5-private-dev libproc2-dev libopencv-dev
+```
+
 **Note:** While opentrack will build without OpenCV, it will only compile with a very minimal subset of its functionality, making it of little use to the average user who does not have very specific usage requirements. 
 
-### Compiling
+### Compiling and running Opentrack
 
-Compiling the project is the same as with any cmake project:
+Compiling and running the project is the same as with any cmake project:
 
 ```bash
 git clone https://github.com/opentrack/opentrack
@@ -25,13 +32,15 @@ cd opentrack/
 cmake .
 make
 make install
+cd ./install/bin
+./opentrack
 ```
 
-**Note:** The resulting build output will be placed in the `install/` directory. It will not 'install' itself anywhere outside of the current directory.
+**Note:** The resulting build output will be placed in the `install/` directory. It will not 'install' itself anywhere outside of the current directory. 
 
 ## Building on Manjaro
 
-### Dependencies
+### Installing Dependencies
 * `cmake`
 * `git`
 * `qt5-tools`

--- a/Building-on-Linux.md
+++ b/Building-on-Linux.md
@@ -9,15 +9,15 @@ The folowing dependencies are required in order to correctly build OpenTrack on 
 * `build-essentials`
 * `cmake`
 * `git`
-* `qttools5-dev`
-* `qtbase5-private-dev`
+* `qt6-tools-dev`
+* `qt6-base-private-dev`
 * `libproc2-dev`
 * `libopencv-dev`
 
 On most Debian/Ubuntu systems the required dependencies can be installed as follows:
 ```sh
 sudo apt update
-sudo apt install build-essential cmake git qttools5-dev qtbase5-private-dev libproc2-dev libopencv-dev
+sudo apt install build-essential cmake git qt6-tools-dev qt6-base-private-dev libproc2-dev libopencv-dev
 ```
 
 **Note:** While opentrack will build without OpenCV, it will only compile with a very minimal subset of its functionality, making it of little use to the average user who does not have very specific usage requirements. 


### PR DESCRIPTION
A few small modifications in building on Debian/Ubuntu guide including:
 - Replace Qt5 dependencies with Qt6 as Qt5 seems to be no longer supported(throws an missing file error when building)
 - Dependencies installation instructions
 - Add instructions for running the program after compiling it under the title "Compiling and Running OpenTrack"