### PR TITLE
Minor tweaks to page "Linux build fixes"

### DIFF
--- a/Building-on-Linux.md
+++ b/Building-on-Linux.md
@@ -11,16 +11,16 @@ The following dependencies are required in order to correctly build Opentrack on
 * `build-essential`
 * `cmake`
 * `git`
-* `qt6-tools-dev`
-* `qt6-base-private-dev`
-* `libproc2-dev`
 * `libopencv-dev`
+* `libproc2-dev`
+* `qt6-base-private-dev`
+* `qt6-tools-dev`
 
 On most Debian/Ubuntu systems the required dependencies can be installed as follows:
 
 ```sh
 sudo apt update
-sudo apt install build-essential cmake git qt6-tools-dev qt6-base-private-dev libproc2-dev libopencv-dev
+sudo apt install build-essential cmake git libopencv-dev libproc2-dev qt6-base-private-dev qt6-tools-dev
 ```
 
 **Note:** While Opentrack will build without OpenCV, it will only compile with a very minimal subset of its functionality, making it of little use to the average user who does not have very specific usage requirements. 

--- a/Building-on-Linux.md
+++ b/Building-on-Linux.md
@@ -5,7 +5,7 @@ Opentrack does not provide binaries for Linux users. The following is a brief, m
 The following dependencies are for **Debian-based** systems, however it should give users of other distros a rough idea of what they will need to hunt for in their own package manager. Users of other distributions are encouraged to expand upon this guide.
 
 ### Installing Dependencies
-The folowing dependencies are required in order to correctly build Opentrack on Debian/Ubuntu systems:
+The following dependencies are required in order to correctly build Opentrack on Debian/Ubuntu systems:
 * `build-essential`
 * `cmake`
 * `git`

--- a/Building-on-Linux.md
+++ b/Building-on-Linux.md
@@ -1,11 +1,11 @@
-Opentrack does not provide binaries for Linux users. The following is a brief, missing guide on compiling opentrack for Linux.
+Opentrack does not provide binaries for Linux users. The following is a brief, missing guide on compiling Opentrack for Linux.
 
 ## Building on Debian, Ubuntu, etc.
 
 The following dependencies are for **Debian-based** systems, however it should give users of other distros a rough idea of what they will need to hunt for in their own package manager. Users of other distributions are encouraged to expand upon this guide.
 
 ### Installing Dependencies
-The folowing dependencies are required in order to correctly build OpenTrack on Debian/Ubuntu systems:
+The folowing dependencies are required in order to correctly build Opentrack on Debian/Ubuntu systems:
 * `build-essential`
 * `cmake`
 * `git`
@@ -20,7 +20,7 @@ sudo apt update
 sudo apt install build-essential cmake git qt6-tools-dev qt6-base-private-dev libproc2-dev libopencv-dev
 ```
 
-**Note:** While opentrack will build without OpenCV, it will only compile with a very minimal subset of its functionality, making it of little use to the average user who does not have very specific usage requirements. 
+**Note:** While Opentrack will build without OpenCV, it will only compile with a very minimal subset of its functionality, making it of little use to the average user who does not have very specific usage requirements. 
 
 ### Compiling and running Opentrack
 

--- a/Building-on-Linux.md
+++ b/Building-on-Linux.md
@@ -6,7 +6,7 @@ The following dependencies are for **Debian-based** systems, however it should g
 
 ### Installing Dependencies
 The folowing dependencies are required in order to correctly build OpenTrack on Debian/Ubuntu systems:
-* `build-essentials`
+* `build-essential`
 * `cmake`
 * `git`
 * `qt6-tools-dev`

--- a/Building-on-Linux.md
+++ b/Building-on-Linux.md
@@ -5,7 +5,9 @@ Opentrack does not provide binaries for Linux users. The following is a brief, m
 The following dependencies are for **Debian-based** systems, however it should give users of other distros a rough idea of what they will need to hunt for in their own package manager. Users of other distributions are encouraged to expand upon this guide.
 
 ### Installing Dependencies
+
 The following dependencies are required in order to correctly build Opentrack on Debian/Ubuntu systems:
+
 * `build-essential`
 * `cmake`
 * `git`
@@ -15,6 +17,7 @@ The following dependencies are required in order to correctly build Opentrack on
 * `libopencv-dev`
 
 On most Debian/Ubuntu systems the required dependencies can be installed as follows:
+
 ```sh
 sudo apt update
 sudo apt install build-essential cmake git qt6-tools-dev qt6-base-private-dev libproc2-dev libopencv-dev
@@ -41,6 +44,7 @@ cd ./install/bin
 ## Building on Manjaro
 
 ### Dependencies
+
 * `cmake`
 * `git`
 * `qt5-tools`


### PR DESCRIPTION
Minor fixes to "Build on Linux" page

STATUS: This Pr might be superceded by https://github.com/opentrack/wiki/pull/8#issuecomment-3263761287, which is a superset of this.

* Fix a "build-essential" package name typo, completing the last outstanding part of https://github.com/opentrack/opentrack/issues/2051. This is intended to be the only substantive semantic change in the PR.
* Sort the list of dependencies.
* Consistent use of markup, black lines around elements.
* Fix a spelling typo.
* Consistent capitalization of project name as "Opentrack".
